### PR TITLE
removed key search in genreNames since we are giving it as a param explicitly

### DIFF
--- a/src/main/java/com/moovy/repository/MovieRepository.java
+++ b/src/main/java/com/moovy/repository/MovieRepository.java
@@ -30,7 +30,6 @@ public interface MovieRepository extends JpaRepository<Movie, Integer> {
             "WHERE LOWER(m.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(m.tagline) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(m.summary) LIKE LOWER(CONCAT('%', :query, '%')) " +
-            "OR LOWER(g.genreName) LIKE LOWER(CONCAT('%', :query, '%'))" +
             "AND (:genreName IS NULL OR LOWER(g.genreName) = LOWER(:genreName))"
     )
     List<Movie> searchMovies(@Param("query") String query,@Param("genreName") String genreName);


### PR DESCRIPTION
1) if we use this then , It is an empty string param to genreName http://localhost:8082/api/v1/movies/search?query=Ent&genreName=

2) if we use this then genreName is null,
http://localhost:8082/api/v1/movies/search?query=Ent